### PR TITLE
Docs Links fixed and line breaks between links added

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,15 +23,15 @@ This directory contains all of the documentation on contributing to freeCodeCamp
 
 ## Quick references articles
 
-<a href="docs/how-to-work-on-guide-articles.md">1. How to work on Guide articles.</a>
-<a href="docs/how-to-work-on-coding-challenges.md">2. How to work on Coding Challenges.</a>
-<a href="docs/how-to-setup-freecodecamp-locally.md">3. How to setup freeCodeCamp locally.</a>
-<a href="docs/how-to-catch-outgoing-emails-locally.md">4. How to catch outgoing emails locally.</a>
+<a href="docs/how-to-work-on-guide-articles.md">1. How to work on Guide articles.</a></br>
+<a href="docs/how-to-work-on-coding-challenges.md">2. How to work on Coding Challenges.</a></br>
+<a href="docs/how-to-setup-freecodecamp-locally.md">3. How to setup freeCodeCamp locally.</a></br>
+<a href="docs/how-to-catch-outgoing-emails-locally.md">4. How to catch outgoing emails locally.</a></br>
 
 ## Style guides
 
-<a href="docs/style-guide-for-guide-articles.md">1. Style guide for creating guide articles.</a>
-<a href="docs/style-guide-for-curriculum-challenges.md">2. Style guide for creating coding challenges.</a>
+<a href="docs/style-guide-for-guide-articles.md">1. Style guide for creating guide articles.</a></br>
+<a href="docs/style-guide-for-curriculum-challenges.md">2. Style guide for creating coding challenges.</a></br>
 
 ## Quick commands reference when working locally
 


### PR DESCRIPTION
The link fixes mentioned in the title were committed by me directly to master without first opening a pull request - apologies for the oversight

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.
